### PR TITLE
change servo frequency to default only if no frequency was given

### DIFF
--- a/pwm.c
+++ b/pwm.c
@@ -519,10 +519,13 @@ static int __init pwm_init(void)
 			goto init_fail;
 	}
 
-	if (servo)
-		frequency = 50;
-	else if (frequency <= 0)
-		frequency = 1024;
+	if (frequency <= 0)
+	{
+		if (servo)
+			frequency = 50;
+		else
+			frequency = 1024;
+	}
 
 	if (servo) {
 		if (servo_min < SERVO_ABSOLUTE_MIN)


### PR DESCRIPTION
Hi Scott,

In case of a brushless motor controller being driven by the PWM, a 50 Hz update rate is usually too low.. Thus, allow also other frequencies in servo mode.

Regards, Tobias
