### PR TITLE
Include uaccess.h to avoid compiler error

### DIFF
--- a/pwm.c
+++ b/pwm.c
@@ -23,7 +23,7 @@
    Jemiah Aitch
    Tobias Simon
 */
-
+#include <linux/uaccess.h>
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/device.h>


### PR DESCRIPTION
Implicit declaration of function 'copy_to_user' will cause an error. uaccess.h has to be included.